### PR TITLE
Fix: Release workflow now targets 'main' branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The release workflow was previously configured to trigger on merges to the 'master' branch. This commit updates the workflow to trigger on merges to the 'main' branch, aligning with the project's current branching strategy.