### PR TITLE
Fix: Trigger Docker image build on release creation

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -11,7 +11,7 @@ name: Publish Docker image
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
The workflow now triggers on release creation instead of publication, allowing for automatic image builds on release drafts. This ensures that images are built and pushed to the registry before the release is actually published.