### PR TITLE
fix: Trigger docker build on release tag creation

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -10,8 +10,11 @@
 name: Publish Docker image
 
 on:
-  release:
-    types: [created]
+  # release:
+  #   types: [created]
+  workflow_run:
+    workflows: ["Create Release and Tag on Merge"]
+    types: [completed]
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
The workflow now builds and pushes a docker image when a new release is tagged, eliminating the need for manual triggering. This ensures a more streamlined process and automates image updates.