### PR TITLE
fix: Include dev dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.10-alpine AS python-deps
 
+COPY requirements_dev.txt /
 COPY requirements_admin.txt /
 COPY requirements.txt /
 


### PR DESCRIPTION
This commit adds `requirements_dev.txt` to the Docker build context, ensuring that development dependencies are included in the built image. This allows for a more robust development environment within the container, as it will now have all necessary tools and libraries for development tasks.