### PR TITLE
Fix: Remove unused dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.10-alpine AS python-deps
 
-COPY requirements_dev.txt /
 COPY requirements_admin.txt /
 COPY requirements.txt /
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ django-cuser==2017.3.16
 
 # Django Admin
 -r requirements_admin.txt
--r requirements_dev.txt
 
 # Miscroservices
 dj-ms-auth-router==1.4.0


### PR DESCRIPTION
The `requirements_dev.txt` file is no longer required, as it's not used anymore. This cleans up the dependencies and simplifies the setup.