### PR TITLE
misc: Enable Docker Buildx for image builds

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -21,6 +21,12 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Check out the repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
This commit enables Docker Buildx in the workflow to leverage its enhanced features for building Docker images. This will provide greater flexibility and support for building multi-platform images, addressing potential limitations of the standard Docker client.