### PR TITLE
misc: Add more tags for docker image

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -41,6 +41,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: redatman/ms-django
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Adds more tags to the docker image to make it easier to find and use.  The new tags include `type=ref,event=branch`, `type=ref,event=pr`, `type=semver,pattern={{version}}`, and `type=semver,pattern={{major}}.{{minor}}`. This will allow users to easily find the latest image, as well as specific versions based on the branch, pull request, or semantic versioning.