### PR TITLE
Fix: Only push Docker image on main branch

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -48,10 +48,11 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           platforms: linux/amd64,linux/arm64
-          # context: .
-          push: true
+          context: .
+          # push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Prevent accidental pushing of Docker images from pull requests. This ensures that only images from the main branch are pushed to Docker Hub.