### PR TITLE
Fix: Always push container image on workflow run

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
-          # push: true
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          # push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Always push the container image to Docker Hub, even for pull requests. This aligns with the desired behavior of building and pushing images for every workflow run, ensuring consistent image availability for testing and deployment purposes. The previous configuration only pushed images on non-pull request events, which could lead to inconsistencies in image availability.