### PR TITLE
Fix: Update Docker image name

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -28,7 +28,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: name/app
+          images: redatman/ms-django
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Updates the Docker image name to reflect the correct repository name, ensuring proper image tagging and pushing to Docker Hub.