### PR TITLE
Fix: Trigger docker image builds on tag pushes and pull requests

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -12,9 +12,15 @@ name: Publish Docker image
 on:
   # release:
   #   types: [created]
-  workflow_run:
-    workflows: ["Create Release and Tag on Merge"]
-    types: [completed]
+  # workflow_run:
+  #   workflows: ["Create Release and Tag on Merge"]
+  #   types: [completed]
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
+  pull_request:
 
 jobs:
   push_to_docker_hub:
@@ -42,7 +48,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -12,15 +12,15 @@ name: Publish Docker image
 on:
   # release:
   #   types: [created]
-  # workflow_run:
-  #   workflows: ["Create Release and Tag on Merge"]
-  #   types: [completed]
-  push:
-    branches:
-      - "**"
-    tags:
-      - "v*.*.*"
-  pull_request:
+  workflow_run:
+    workflows: ["Create Release and Tag on Merge"]
+    types: [completed]
+  # push:
+  #   branches:
+  #     - "**"
+  #   tags:
+  #     - "v*.*.*"
+  # pull_request:
 
 jobs:
   push_to_docker_hub:


### PR DESCRIPTION
Expanded the CI workflow to trigger Docker image builds on tag pushes and pull requests, enabling more frequent and automated deployments. This change simplifies the release process by removing the dependence on a separate release workflow.