### PR TITLE
fix: enable QEMU for Docker builds

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -27,8 +27,8 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Enables QEMU in the Docker build workflow to support building images for different architectures. This allows for building and pushing images to Docker Hub for a wider range of environments.