### PR TITLE
Fix: Update semver pattern for release workflow

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -46,7 +46,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}"
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
The semver pattern used for triggering releases was missing a closing quote, preventing the workflow from identifying correct versions. This commit adds the missing quote.