### PR TITLE
fix: Support pushing images tagged with latest on main branch

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -45,9 +45,12 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Add a new trigger to the Docker Hub workflow that pushes an image tagged with `latest` to the repository whenever a commit is pushed to the main branch. This ensures that the latest image is always available for users and automates the process of tagging and pushing the default image.