### PR TITLE
Fix: Enable automated docker image tagging

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -41,16 +41,16 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: redatman/ms-django
-          # tags: |
-          #   type=schedule
-          #   type=ref,event=branch
-          #   type=ref,event=pr
-          #   type=ref,event=tag
-          #   type=semver,pattern={{version}}
-          #   type=semver,pattern={{major}}.{{minor}}.{{patch}}
-          #   type=semver,pattern={{major}}.{{minor}}
-          #   type=semver,pattern={{major}}
-          #   type=raw,value=latest,enable={{is_default_branch}}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
This commit enables automated tagging of Docker images on Docker Hub.

Previously, image tagging was commented out, preventing automatic tagging based on different criteria.

The change now allows tags to be generated based on schedule, branch, pull request, tag, and semantic versioning patterns. It also sets `latest` as a tag for the default branch.