### PR TITLE
fix(ci): Trigger on tag push and published releases

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -12,15 +12,20 @@ name: Publish Docker image
 on:
   # release:
   #   types: [created]
-  workflow_run:
-    workflows: ["Create Release and Tag on Merge"]
-    types: [completed]
+  # workflow_run:
+  #   workflows: ["Create Release and Tag on Merge"]
+  #   types: [completed]
   # push:
   #   branches:
   #     - "**"
   #   tags:
   #     - "v*.*.*"
   # pull_request:
+  push:
+    tags:
+      - '*'  # Trigger on any tag push
+  release:
+    types: [published]  # Trigger when a new release is published
 
 jobs:
   # push_to_docker_hub:


### PR DESCRIPTION
This change ensures the Docker image is built and pushed to Docker Hub when a new tag is pushed or a new release is published. This addresses the need for automated image updates without relying on a specific workflow trigger like "Create Release and Tag on Merge" and provides greater flexibility in triggering image builds.