### PR TITLE
fix(ci): Fetch all tags for Docker image build

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Ensure all tags are fetched
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -90,6 +92,7 @@ jobs:
         id: extract_tag
         run: |
           TAG=${GITHUB_REF#refs/tags/}
+          echo "Image tag: $TAG"
           echo "TAG=${TAG}" >> $GITHUB_ENV
 
       - name: Build and tag Docker image


### PR DESCRIPTION
Ensure all Git tags are fetched when building Docker images to properly tag the image based on the release tag. This allows for more reliable and consistent tagging of Docker images.