### PR TITLE
Fix(ci): Default to `latest` tag for non-tag pushes

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -91,9 +91,13 @@ jobs:
       - name: Extract GitHub tag
         id: extract_tag
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          echo "Image tag: $TAG"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAG=${GITHUB_REF#refs/tags/}
+          else
+            TAG=latest  # Default to "latest" for non-tag pushes
+          fi
+          echo "Docker tag: $TAG"
+          echo "TAG=$TAG" >> $GITHUB_ENV
 
       - name: Build and tag Docker image
         run: |


### PR DESCRIPTION
When pushing to Docker Hub, the workflow now defaults to the `latest` tag if the push is not triggered by a tag. This ensures that non-tag pushes (like branch commits) still result in a build and push to Docker Hub.