### PR TITLE
Fix(ci): Enable Docker image build on release

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -10,9 +10,9 @@
 name: Publish Docker image
 
 on:
-  # release:
-  #   types: [created]
-  #   types: [published]  # Trigger when a new release is published
+  release:
+    # types: [created]
+    types: [published]  # Trigger when a new release is published
   # push:
   #   branches:
   #     - "**"
@@ -45,16 +45,16 @@ jobs:
           images: redatman/ms-django
           tags: |
             type=schedule
-            # type=ref,event=branch
+            type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{tag}}
             type=semver,pattern={{raw}}
             type=semver,pattern={{version}}
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Enable Docker image builds to be triggered by releases published on GitHub, allowing for automated deployment of new versions.