### PR TITLE
fix(ci): Only push 'latest' tag for main branch and tagged releases

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -59,9 +59,9 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
             type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           #   type=ref,event=branch,suffix=-{{ sha }}
           #   type=ref,event=pr
-          #   type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           # flavor: |
           #   latest=false
 


### PR DESCRIPTION
The workflow previously pushed the 'latest' tag for any branch, but it should only be pushed for the `main` branch and tagged releases. This ensures that the 'latest' tag accurately reflects the latest stable version.