### PR TITLE
Fix(ci): Add tag for latest PR/Branch build

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -29,11 +29,11 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -60,8 +60,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
             type=semver,pattern={{major}},value=${{ inputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-          #   type=ref,event=branch,suffix=-{{ sha }}
-          #   type=ref,event=pr
+            type=ref,event=branch,suffix=-{{ sha }}
+            type=ref,event=pr
           # flavor: |
           #   latest=false
 
@@ -74,7 +74,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This commit introduces a tag for the latest build from a pull request or branch. This will enable easier identification and retrieval of specific build artifacts. The tag format includes the commit SHA for better traceability.