### PR TITLE
fix(ci): Enable Docker Buildx in CI workflow

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -32,8 +32,8 @@ jobs:
       # - name: Set up QEMU
       #   uses: docker/setup-qemu-action@v3
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Docker Buildx has been enabled in the CI workflow for building and pushing Docker images. This allows for improved performance and enhanced flexibility when building images on multiple platforms.