### PR TITLE
fix(ci): Tagging strategy for Docker images

### DIFF
--- a/.github/workflows/build-and-push-to-docker-hub.yml
+++ b/.github/workflows/build-and-push-to-docker-hub.yml
@@ -58,9 +58,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
-            # type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ inputs.tag }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-            type=ref,event=branch,suffix=-{{ sha }}
             type=ref,event=pr
           # flavor: |
           #   latest=false


### PR DESCRIPTION
This change simplifies the tagging strategy for Docker images by removing unnecessary and redundant tags.  The new strategy uses `type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ inputs.tag }}` for all versions, ensuring consistent and accurate tagging.  The `latest` tag is applied only when building from the `main` branch or a tag.