### PR TITLE
misc: Add org hierarchy support

### DIFF
--- a/requirements_admin.txt
+++ b/requirements_admin.txt
@@ -6,3 +6,6 @@ django-unfold==0.37.0
 # Authorization
 # Per object permissions for Django
 django-guardian
+
+# Organizations
+django-orghierarchy==0.4.0


### PR DESCRIPTION
Adds the `django-orghierarchy` package to enable organizational hierarchy management. This will allow for more robust and flexible organizational structures within the application.