### PR TITLE
fix: Temporarily disable authentication API

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -30,7 +30,7 @@ URL_PREFIX = settings.APP_LABEL + '/' if settings.APP_LABEL else ''
 
 urlpatterns = [
     path(URL_PREFIX + 'admin/', admin.site.urls),
-    path('api/auth/', include('authentication.api.urls'), name='authentication'),
+    # path('api/auth/', include('authentication.api.urls'), name='authentication'),
 ]
 
 


### PR DESCRIPTION
The authentication API endpoints have been temporarily disabled for further development. The code remains in place, commented out, and will be re-enabled later.