### PR TITLE
fix: Allow database connection via environment variable

### DIFF
--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -142,7 +142,7 @@ ROUTE_APP_LABELS = []
 AUTH_DB = 'default'
 
 DATABASES = {
-    'default': dj_database_url.config(default='sqlite:///db.sqlite3', conn_max_age=600)
+    'default': dj_database_url.config(default=os.getenv('DATABASE_URL', 'sqlite:///db.sqlite3'), conn_max_age=600)
 }
 
 if auth_db := os.getenv('AUTH_DB_URL'):


### PR DESCRIPTION
The database connection can now be configured through the `DATABASE_URL` environment variable. This allows for easier deployment and management of the database connection across different environments.